### PR TITLE
Allow injection of Nullable Connection type

### DIFF
--- a/common/src/main/x/common/DbInjector.x
+++ b/common/src/main/x/common/DbInjector.x
@@ -57,11 +57,17 @@ service DbInjector(AppHost appHost, DbHost[] dbHosts)
 
     @Override
     Supplier getResource(Type type, String name) {
+        Boolean isNullable = False;
+        Type    sansNull   = type;
+        if (sansNull := type.isNullable()) {
+            isNullable = True;
+        }
+
         // first, check for any subclass of the "RootSchema"
-        if (type.is(Type<RootSchema>)) {
-            Type schemaType = type;
-            if (type.is(Type<Connection>)) {
-                assert schemaType := type.resolveFormalType("Schema");
+        if (sansNull.is(Type<RootSchema>)) {
+            Type schemaType = sansNull;
+            if (schemaType.is(Type<Connection>)) {
+                assert schemaType := schemaType.resolveFormalType("Schema");
             }
 
             // Note, that we activate the dbHosts during the container validation phase to minimize
@@ -74,7 +80,7 @@ service DbInjector(AppHost appHost, DbHost[] dbHosts)
                     Type hostSchemaType = dbHost.schemaType;
                     Type hostConnType   = hostSchemaType + Connection.as(Type).parameterize([hostSchemaType]);
                     if (hostConnType.isA(schemaType)) {
-                        return (Inject.Options opts) -> maskConnection(createConnection, type);
+                        return (Inject.Options opts) -> maskConnection(createConnection, sansNull);
                     }
                 } else {
                     errors.reportAll(consoleImpl.print);
@@ -84,8 +90,8 @@ service DbInjector(AppHost appHost, DbHost[] dbHosts)
             throw new Exception($"Failed to find a database for {schemaType}");
         }
 
-        switch (type, name) {
-        case (Authenticator?, "authenticator"):
+        switch (sansNull, name) {
+        case (Authenticator, "authenticator"):
             return (Inject.Options opts) -> {
                 if (WebAppInfo appInfo := appHost.appInfo.is(WebAppInfo), appInfo.useAuth) {
 

--- a/common/src/main/x/common/HostInjector.x
+++ b/common/src/main/x/common/HostInjector.x
@@ -105,7 +105,13 @@ service HostInjector(AppHost appHost)
     Supplier getResource(Type type, String name) {
         import Container.Linker;
 
-        switch (type, name) {
+        Boolean isNullable = False;
+        Type    sansNull   = type;
+        if (sansNull := type.isNullable()) {
+            isNullable = True;
+        }
+
+        switch (sansNull, name) {
         case (Console, "console"):
             if (platform) {
                 @Inject Console console;
@@ -169,7 +175,7 @@ service HostInjector(AppHost appHost)
                 return &temp.maskAs(Directory);
 
             default:
-                throw new Exception($"Invalid Directory resource: \"{name}\"");
+                throw new Exception($"Invalid Directory resource: {name.quoted()}");
             }
 
         case (Random, "random"):
@@ -203,7 +209,7 @@ service HostInjector(AppHost appHost)
                 return keystore;
             };
 
-        case (Broker?, "sessionBroker"):
+        case (Broker, "sessionBroker"):
             return (Inject.Options opts) -> {
                 WebApp webApp;
                 if (platform) {
@@ -260,20 +266,27 @@ service HostInjector(AppHost appHost)
                 return (Inject.Options opts) -> injector.inject(type, name, opts);
             }
 
-            // see utils.collectDestringableInjections()
-            if (AppInfo appInfo ?= appHost.appInfo,
-                String  value   := appInfo.injections.get(new InjectionKey(name, type.toString()))) {
-                assert type.is(Type<Destringable>) as $"Type is not Destringable: \"{type}\"";
-                return new type.DataType(value);
-            }
-            if (Null.is(type)) {
-                // allow any Nullable injections that we are not aware of
-                return Null;
+            // TODO: remove the try-catch when Type.toString() is guaranteed not to throw
+            String typeName;
+            try {
+                typeName = sansNull.toString();
+
+                // see utils.collectDestringableInjections()
+                if (AppInfo appInfo ?= appHost.appInfo,
+                    String  value   := appInfo.injections.get(new InjectionKey(name, typeName))) {
+                    assert sansNull.is(Type<Destringable>) as $"Type is not Destringable: {typeName.quoted()}";
+                    return new sansNull.DataType(value);
+                }
+                if (isNullable) {
+                    // allow any Nullable injections that we are not aware of
+                    return Null;
+                }
+            } catch (Exception e)  {
+                typeName = "[foreign type]";
             }
 
             return (Inject.Options opts) ->
-                throw new Exception($|Invalid resource: name="{name}", type="{type}"
-                                   );
+                throw new Exception($"Invalid resource: name={name.quoted()}, type={typeName.quoted()}");
         }
     }
 }


### PR DESCRIPTION
This change is complementary to the [similar change in the xvm platform](https://github.com/xtclang/xvm/pull/409)

It allows the apps deployed onto the Platform to have optional injections; which can be useful if the corresponding module is used in a standalone mode, allowing manual creation of a DB connection in that case