### PR TITLE
Add a receiver update retry upon platform start

### DIFF
--- a/common/src/main/x/common.x
+++ b/common/src/main/x/common.x
@@ -42,18 +42,6 @@ module common.xqiz.it {
     }
 
     /**
-     * Create a fixed length string with the specified (or current) time.
-     */
-    static String logTime(Time? time = Null) {
-        if (time == Null) {
-            @Inject Clock clock;
-            time = clock.now;
-        }
-
-        return appendLogTime(new StringBuffer(23), time).toString();
-    }
-
-    /**
      * Append the specified (or current) time into the buffer as a fixed length string.
      *
      * This helper exists to be used within Ecstasy template strings, e.g.

--- a/common/src/main/x/common/ProxyManager.x
+++ b/common/src/main/x/common/ProxyManager.x
@@ -8,6 +8,11 @@ import crypto.KeyStore;
 interface ProxyManager {
 
     /**
+     * Maximum allowed update duration.
+     */
+    @RO Duration updateTimeout;
+
+    /**
      * Send the proxy config updates updates to all proxies. The success of this operation may
      * depend on the configuration of the required proxies and the timeout.
      *

--- a/common/src/main/x/common/ProxyManager.x
+++ b/common/src/main/x/common/ProxyManager.x
@@ -8,16 +8,19 @@ import crypto.KeyStore;
 interface ProxyManager {
 
     /**
-     * Send the proxy config updates updates to all proxies.
+     * Send the proxy config updates updates to all proxies. The success of this operation may
+     * depend on the configuration of the required proxies and the timeout.
      *
      * @param keystore  the keystore
      * @param pwd       the password for the keystore
      * @param keyName   the key name for the key/certificate pair
      * @param hostName  the host name to be updated
      * @param report    the function to report errors to
+     *
+     * @return `True` if the proxy configuration was successfully updated
      */
-     void updateProxyConfig(KeyStore keystore, CryptoPassword pwd,
-                            String keyName, String hostName, Reporting report);
+     Boolean updateProxyConfig(KeyStore keystore, CryptoPassword pwd, String keyName, String hostName,
+                               Reporting report);
 
     /**
      * Notify all proxies that a config needs to be removed.
@@ -34,8 +37,8 @@ interface ProxyManager {
         construct() {} finally { makeImmutable(); }
 
         @Override
-        void updateProxyConfig(KeyStore keystore, CryptoPassword pwd,
-                            String keyName, String hostName, Reporting report) {}
+        Boolean updateProxyConfig(KeyStore keystore, CryptoPassword pwd,
+                               String keyName, String hostName, Reporting report) = True;
 
         @Override
         void removeProxyConfig(String hostName, Reporting report) {}

--- a/common/src/main/x/common/utils.x
+++ b/common/src/main/x/common/utils.x
@@ -238,6 +238,54 @@ package utils {
         decryptor.decrypt(Base64Format.Instance.decode(value)).unpackUtf8();
 
     /**
+     * Repeatedly invoke the specified action until it returns a value other than `retryValue`, or
+     * until the timeout is reached. Any exception raised by the action is ignored and causes the
+     * action to be retried.
+     *
+     * @param action      the action function
+     * @param timeout     the maximum time allowed for all attempts, including delays between retries
+     * @param retryValue  the `Result` value indicating that the action should be retried; this
+     *                    value is also returned if the timeout is reached
+     * @param retryDelay  (optional) delay between attempts; if not specified, a delay is computed
+     *                    automatically to allow up to five retries, with a minimum delay of one
+     *                    second
+     */
+    static <Result> Result repeatAction(function Result() action, Duration timeout,
+                                        Result retryValue, Duration? retryDelay = Null) {
+        @Inject Clock clock;
+
+        if (retryDelay == Null) {
+            retryDelay = (timeout/5).notLessThan(Second);
+        }
+
+        Time start = clock.now;
+        try (val _ = new Timeout(timeout)) {
+            Result result = action();
+            if (result != retryValue) {
+                return result;
+            }
+            // retry result; schedule another attempt
+        } catch (TimedOut e) {
+            return retryValue;
+        } catch (Exception _) {
+            // ignore any other exception and schedule another attempt
+        }
+
+        // adjust the timeout, accounting for the upcoming repeat wait time
+        timeout = timeout - (clock.now - start) - retryDelay;
+        if (timeout.sign != Positive) {
+            return retryValue;
+        }
+
+        // repeat as specified
+        @Future Result result;
+        clock.schedule(retryDelay, () -> {
+            result = repeatAction^(action, timeout, retryValue, retryDelay);
+        });
+        return result;
+    }
+
+    /**
      * A "new line" character as a Byte[].
      */
     static Byte[] NewLine = ['\n'.toByte()];

--- a/kernel/src/main/x/kernel.x
+++ b/kernel/src/main/x/kernel.x
@@ -56,6 +56,7 @@ module kernel.xqiz.it {
 
     import xenia.HttpServer;
 
+    @Inject Clock   clock;
     @Inject Console console;
 
     void run(String[] args=[]) {
@@ -198,11 +199,12 @@ module kernel.xqiz.it {
                 if (ModuleTemplate proxyModule := repository.getModule("proxy_manager.xqiz.it")) {
                     proxyModule = proxyModule.parent.resolve(repository).mainModule;
 
-                    (Uri[] receivers, proxyIPs) = parseProxies(proxies);
+                    Duration timeoutDuration = new Duration(timeout);
+                    (Uri[] receivers, proxyIPs) = parseProxies(proxies, timeoutDuration);
                     if (Container container :=
                             utils.createContainer(repository, proxyModule, pseudoHost, errors)) {
                         proxyManager = container.invoke("configure",
-                            Tuple:(receivers, required, new Duration(timeout)))[0].as(ProxyManager);
+                            Tuple:(receivers, required, timeoutDuration))[0].as(ProxyManager);
                     } else {
                         return;
                     }
@@ -264,7 +266,7 @@ module kernel.xqiz.it {
         }
     }
 
-    private (Uri[] uris, IPAddress[] addrs) parseProxies(String[] proxies) {
+    private (Uri[] uris, IPAddress[] addrs) parseProxies(String[] proxies, Duration timeout) {
         @Inject("secureNetwork") net.Network network;
 
         Int         count = proxies.size;
@@ -288,12 +290,42 @@ module kernel.xqiz.it {
                     console.print($"Error: Failed to lookup the proxy name: {proxy.quoted()}");
                 }
             } else {
-                assert IPAddress[] ips := network.nameService.resolve(addr), !ips.empty as
-                    $"Unresolvable proxy name: {proxy.quoted()}";
+                IPAddress[] ips = resolve(network.nameService, addr, clock.now + timeout);
+                assert !ips.empty as $"Unresolvable proxy name: {proxy.quoted()}";
+
                 addrs += ips; // if more than one (quite rare), add them all
-                uris += new Uri(scheme="https", host=addr, port=port);
+                uris  += new Uri(scheme="https", host=addr, port=port);
             }
         }
         return uris.freeze(inPlace=True), addrs.freeze(inPlace=True);
     }
+
+    /**
+     * Resolve the specified address.
+     */
+    private IPAddress[] resolve(net.NameService nameService, String addr, Time cutoff) {
+        Time now = clock.now;
+        if (now > cutoff) {
+            return [];
+        }
+
+        try (val _ = new Timeout(cutoff - now)) {
+            if (IPAddress[] ips := nameService.resolve(addr), !ips.empty) {
+                return ips;
+            }
+            // ignore a negative response and repeat in two seconds
+        } catch (TimedOut e) {
+            return [];
+        } catch (Exception _) {
+            // ignore any other exception and repeat in two seconds
+        }
+
+        // repeat in two seconds
+        @Future IPAddress[] ips;
+        clock.schedule(Duration.ofSeconds(2), () -> {
+            ips = resolve^(nameService, addr, cutoff);
+        });
+        return ips;
+    }
+
 }

--- a/kernel/src/main/x/kernel.x
+++ b/kernel/src/main/x/kernel.x
@@ -46,6 +46,7 @@ module kernel.xqiz.it {
     import crypto.NamedPassword;
 
     import json.Doc;
+    import json.JsonObject;
     import json.Parser;
 
     import net.IPAddress;
@@ -73,7 +74,7 @@ module kernel.xqiz.it {
         Directory hostDir     = platformDir.dirFor("host").ensure();
 
         // get the configuration
-        Map<String, Doc> config;
+        JsonObject config;
         try {
             File   configFile = platformDir.fileFor("cfg.json");
             File   configInit = /cfg.json;
@@ -92,7 +93,7 @@ module kernel.xqiz.it {
                 configFile.contents = configData;
             }
 
-            config = new Parser(jsonConfig.toReader()).parseDoc().as(Map<String, Doc>);
+            config = new Parser(jsonConfig.toReader()).parseDoc().as(JsonObject);
         } catch (Exception e) {
             console.print($"Error: Invalid config file");
             return;
@@ -108,6 +109,9 @@ module kernel.xqiz.it {
             UInt16   httpsPort = config.getOrDefault("httpsPort", 8090).as(IntLiteral).toUInt16();
             String[] proxies   = config.getOrDefault("proxies", []).as(Doc[])
                                        .map(addr -> addr.as(String)).toArray();
+            Int      required  = config.getOrDefault("proxies-required", 1).as(IntLiteral).toInt()
+                                       .minOf(proxies.size).maxOf(0);
+            String   timeout   = config.getOrDefault("proxies-timeout", "10S").as(String);
 
             assert String hostName := dName.splitMap().get("CN"), hostName.count('.') >= 2
                     as "Invalid \"dName\" configuration value";
@@ -197,7 +201,8 @@ module kernel.xqiz.it {
                     (Uri[] receivers, proxyIPs) = parseProxies(proxies);
                     if (Container container :=
                             utils.createContainer(repository, proxyModule, pseudoHost, errors)) {
-                        proxyManager = container.invoke("configure", Tuple:(receivers))[0].as(ProxyManager);
+                        proxyManager = container.invoke("configure",
+                            Tuple:(receivers, required, new Duration(timeout)))[0].as(ProxyManager);
                     } else {
                         return;
                     }

--- a/kernel/src/main/x/kernel.x
+++ b/kernel/src/main/x/kernel.x
@@ -56,7 +56,6 @@ module kernel.xqiz.it {
 
     import xenia.HttpServer;
 
-    @Inject Clock   clock;
     @Inject Console console;
 
     void run(String[] args=[]) {
@@ -290,7 +289,15 @@ module kernel.xqiz.it {
                     console.print($"Error: Failed to lookup the proxy name: {proxy.quoted()}");
                 }
             } else {
-                IPAddress[] ips = resolve(network.nameService, addr, clock.now + timeout);
+                function IPAddress[] () resolve = () -> {
+                    if (IPAddress[] ips := network.nameService.resolve(addr)) {
+                        return ips;
+                    } else {
+                        return [];
+                    }
+                };
+
+                IPAddress[] ips = utils.repeatAction(resolve, timeout, []);
                 assert !ips.empty as $"Unresolvable proxy name: {proxy.quoted()}";
 
                 addrs += ips; // if more than one (quite rare), add them all
@@ -299,33 +306,4 @@ module kernel.xqiz.it {
         }
         return uris.freeze(inPlace=True), addrs.freeze(inPlace=True);
     }
-
-    /**
-     * Resolve the specified address.
-     */
-    private IPAddress[] resolve(net.NameService nameService, String addr, Time cutoff) {
-        Time now = clock.now;
-        if (now > cutoff) {
-            return [];
-        }
-
-        try (val _ = new Timeout(cutoff - now)) {
-            if (IPAddress[] ips := nameService.resolve(addr), !ips.empty) {
-                return ips;
-            }
-            // ignore a negative response and repeat in two seconds
-        } catch (TimedOut e) {
-            return [];
-        } catch (Exception _) {
-            // ignore any other exception and repeat in two seconds
-        }
-
-        // repeat in two seconds
-        @Future IPAddress[] ips;
-        clock.schedule(Duration.ofSeconds(2), () -> {
-            ips = resolve^(nameService, addr, cutoff);
-        });
-        return ips;
-    }
-
 }

--- a/platformUI/src/main/x/platformUI.x
+++ b/platformUI/src/main/x/platformUI.x
@@ -38,6 +38,7 @@ module platformUI.xqiz.it {
 
     import sec.Realm;
 
+    import web.HttpClient;
     import web.HttpsRequired;
     import web.StaticContent;
     import web.WebApp;
@@ -80,6 +81,13 @@ module platformUI.xqiz.it {
             AcmeChallenge = () -> new AcmeChallenge(homeDir.dirFor(".challenge").ensure()),
             ];
 
+        Boolean selfSigner = provider == names.SelfSigner;
+
+        // if we ever need to create or update the certificate we need to activate the challenge app
+        if (!selfSigner) {
+            server.addRoute(route, new HttpHandler(route, hostManager.challengeApp, extras));
+        }
+
         (Boolean valid, Boolean exists) = checkCertificate(keystore, hostName, provider);
         if (valid) {
             // they could have configured new proxies; need to update them just in case
@@ -92,8 +100,6 @@ module platformUI.xqiz.it {
             clock.schedule(Duration.ofDays(7), () ->
                     ensureCertificate(keystore, pwd, hostName, dName, provider, homeDir, proxyManager));
         } else {
-            Boolean selfSigner = provider == names.SelfSigner;
-
             // if there are any proxies, we need to make sure they have registered a route to the
             // platform server; we don't need a valid cert for that, anything will do
             if (exists && !selfSigner) {
@@ -112,9 +118,13 @@ module platformUI.xqiz.it {
             // for self-signer we've already created a valid certificate and the proxies have been
             // updated; there is nothing else to do
             if (!selfSigner) {
-                // before we proceed we need to create a certificate; for that to work (unless the
-                // provider is self-signing), we need to activate the challenge app
-                server.addRoute(route, new HttpHandler(route, hostManager.challengeApp, extras));
+                // before we proceed we need to create a certificate, but before we talk to the CA
+                // provider we need to make sure that it can reach us; otherwise our requests for
+                // the certificate may look like an abuse
+                if (!checkReachability(
+                        new HttpClient(), hostName, clock.now + proxyManager.updateTimeout)) {
+                    throw new Exception("The host {hostName.quoted()} is not reachable");
+                }
 
                 @Future Tuple result = createCertificate^(
                         keystore, pwd, hostName, dName, provider, homeDir, proxyManager);
@@ -285,6 +295,38 @@ module platformUI.xqiz.it {
         proxyManager.updateProxyConfig^(keystore, pwd, names.PlatformTlsKey, hostName,
             msg -> console.print($"{common.logTime($)} {msg}"));
         return keystore;
+    }
+
+    /**
+     * Check if the specified host name is reachable over HTTP.
+     */
+    private Boolean checkReachability(HttpClient client, String hostName, Time cutoff) {
+        import web.ResponseIn;
+
+        Time now = clock.now;
+        if (now > cutoff) {
+            return False;
+        }
+
+        try (val _ = new Timeout(cutoff - now)) {
+            String uri = $"http://{hostName}/.well-known/self-test";
+
+            // the "self-test" is a non-exising resource, so 404 is the positive response;
+            // treat any other response as a "need to repeat" attempt
+            ResponseIn result = client.get(uri);
+            if (result.status == NotFound) {
+                return True;
+            }
+        } catch (TimedOut e) {
+            return False;
+        }
+
+        // repeat in two seconds
+        @Future Boolean done;
+        clock.schedule(Duration.ofSeconds(2), () -> {
+            done = checkReachability^(client, hostName, cutoff);
+        });
+        return done;
     }
 
     /**

--- a/platformUI/src/main/x/platformUI.x
+++ b/platformUI/src/main/x/platformUI.x
@@ -83,8 +83,10 @@ module platformUI.xqiz.it {
         (Boolean valid, Boolean exists) = checkCertificate(keystore, hostName, provider);
         if (valid) {
             // they could have configured new proxies; need to update them just in case
-            proxyManager.updateProxyConfig^(keystore, pwd, names.PlatformTlsKey, hostName,
-                msg -> console.print($"{common.logTime($)} {msg}"));
+            if (!proxyManager.updateProxyConfig(keystore, pwd, names.PlatformTlsKey, hostName,
+                    msg -> console.print($"{common.logTime($)} {msg}"))) {
+                throw new Exception("Failed to update the proxy configuration");
+            }
 
             // schedule the next check in a week
             clock.schedule(Duration.ofDays(7), () ->
@@ -96,8 +98,10 @@ module platformUI.xqiz.it {
             // platform server; we don't need a valid cert for that, anything will do
             if (exists && !selfSigner) {
                 // wait for the manager to get back a confirmation, so we can proceed with signing
-                proxyManager.updateProxyConfig(keystore, pwd, names.PlatformTlsKey, hostName,
-                    msg -> console.print($"{common.logTime($)} {msg}"));
+                if (!proxyManager.updateProxyConfig(keystore, pwd, names.PlatformTlsKey,
+                        hostName, msg -> console.print($"{common.logTime($)} {msg}"))) {
+                    throw new Exception("Failed to update the proxy configuration");
+                }
             } else {
                 // with any provider we have to start with a self-signed one to register the route;
                 // only then we can ask the "real" provider to supply a valid certificate

--- a/platformUI/src/main/x/platformUI.x
+++ b/platformUI/src/main/x/platformUI.x
@@ -23,6 +23,7 @@ module platformUI.xqiz.it {
     import common.WebHost;
 
     import common.names;
+    import common.utils;
 
     import common.model.AccountInfo;
     import common.model.AppInfo;
@@ -121,8 +122,15 @@ module platformUI.xqiz.it {
                 // before we proceed we need to create a certificate, but before we talk to the CA
                 // provider we need to make sure that it can reach us; otherwise our requests for
                 // the certificate may look like an abuse
-                if (!checkReachability(
-                        new HttpClient(), hostName, clock.now + proxyManager.updateTimeout)) {
+                HttpClient client = new HttpClient();
+                function Boolean () checkReachability = () -> {
+                    // the "self-test" is a non-exising resource, so 404 is the positive response;
+                    // treat any other response as a "need to repeat" attempt
+                    String uri = $"http://{hostName}/.well-known/self-test";
+                    return client.get(uri).status == NotFound;
+                };
+
+                if (!utils.repeatAction(checkReachability, proxyManager.updateTimeout, False)) {
                     throw new Exception("The host {hostName.quoted()} is not reachable");
                 }
 
@@ -295,38 +303,6 @@ module platformUI.xqiz.it {
         proxyManager.updateProxyConfig^(keystore, pwd, names.PlatformTlsKey, hostName,
             msg -> console.print($"{common.logTime($)} {msg}"));
         return keystore;
-    }
-
-    /**
-     * Check if the specified host name is reachable over HTTP.
-     */
-    private Boolean checkReachability(HttpClient client, String hostName, Time cutoff) {
-        import web.ResponseIn;
-
-        Time now = clock.now;
-        if (now > cutoff) {
-            return False;
-        }
-
-        try (val _ = new Timeout(cutoff - now)) {
-            String uri = $"http://{hostName}/.well-known/self-test";
-
-            // the "self-test" is a non-exising resource, so 404 is the positive response;
-            // treat any other response as a "need to repeat" attempt
-            ResponseIn result = client.get(uri);
-            if (result.status == NotFound) {
-                return True;
-            }
-        } catch (TimedOut e) {
-            return False;
-        }
-
-        // repeat in two seconds
-        @Future Boolean done;
-        clock.schedule(Duration.ofSeconds(2), () -> {
-            done = checkReachability^(client, hostName, cutoff);
-        });
-        return done;
     }
 
     /**

--- a/proxy/src/main/x/proxy.x
+++ b/proxy/src/main/x/proxy.x
@@ -13,8 +13,8 @@ module proxy_manager.xqiz.it {
     /**
      * Bootstrapping: configure and return the ProxyManager.
      */
-    common.ProxyManager configure(Uri[] receivers) {
-        ProxyManager mgr = new ProxyManager(receivers);
+    common.ProxyManager configure(Uri[] receivers, Int required, Duration updateTimeout) {
+        ProxyManager mgr = new ProxyManager(receivers, required, updateTimeout);
         return &mgr.maskAs(common.ProxyManager);
     }
 }

--- a/proxy/src/main/x/proxy/ProxyManager.x
+++ b/proxy/src/main/x/proxy/ProxyManager.x
@@ -6,6 +6,7 @@ import crypto.CryptoPassword;
 import crypto.KeyStore;
 
 import common.Reporting;
+import common.utils;
 
 import web.Client;
 import web.HttpClient;
@@ -57,7 +58,6 @@ service ProxyManager(Uri[] receivers, Int required, Duration updateTimeout)
                       );
         }
         String pemCert = buf.toString();
-        Time   cutoff  = clock.now + updateTimeout;
 
         @Future Boolean allDone;
         Future<Boolean> done = &allDone;
@@ -66,7 +66,7 @@ service ProxyManager(Uri[] receivers, Int required, Duration updateTimeout)
 
         for (Uri receiver : receivers) {
             Updater updater = new Updater(receiver, pemKey, pemCert, hostName, report);
-            Boolean success = updater.updateProxy^(cutoff);
+            Boolean success = updater.updateProxy^(updateTimeout);
             &success.whenComplete((r, x) -> {
                 if (r == True) {
                     if (++successCount >= required) {
@@ -107,26 +107,8 @@ service ProxyManager(Uri[] receivers, Int required, Duration updateTimeout)
         /**
          * Async update.
          */
-        Boolean updateProxy(Time cutoff) {
-            Time now = clock.now;
-            if (now > cutoff) {
-                return False;
-            }
-
-            try (val _ = new Timeout(cutoff - now)) {
-                if (update()) {
-                    return True;
-                }
-            } catch (TimedOut e) {
-                return False;
-            }
-
-            // repeat in two seconds
-            @Future Boolean done;
-            clock.schedule(Duration.ofSeconds(2), () -> {
-                done = updateProxy^(cutoff);
-            });
-            return done;
+        Boolean updateProxy(Duration timeout) {
+            return utils.repeatAction(&update, timeout, False);
         }
 
         /**

--- a/proxy/src/main/x/proxy/ProxyManager.x
+++ b/proxy/src/main/x/proxy/ProxyManager.x
@@ -13,28 +13,32 @@ import web.ResponseIn;
 
 /**
  * The proxy management API.
+ *
+ * @param receivers      the receivers associated with proxy servers
+ * @param required       the minimum number of proxies that are required to be successfully updated for
+ *                       the [updateProxyConfig] operation to claim success
+ * @param updateTimeout  the timeout duration for receivers' updates
  */
-service ProxyManager(Uri[] receivers)
+service ProxyManager(Uri[] receivers, Int required, Duration updateTimeout)
         implements common.ProxyManager {
 
-    /**
-     * The receivers associated with proxy servers.
-     */
+    @Inject Clock clock;
+
     private Uri[] receivers;
+    private Int   required;
+
+    assert() {
+        assert 0 <= required <= receivers.size;
+    }
 
     /**
      * The client used to talk to external services.
      */
     @Lazy Client client.calc() = new HttpClient();
 
-    /**
-     * The timeout duration for receivers' updates.
-     */
-    static Duration receiverTimeout = Duration.ofSeconds(10);
-
     @Override
-    void updateProxyConfig(KeyStore keystore, CryptoPassword pwd,
-                           String keyName, String hostName, Reporting report) {
+    Boolean updateProxyConfig(KeyStore keystore, CryptoPassword pwd,
+                              String keyName, String hostName, Reporting report) {
         @Inject CertificateManager manager;
 
         Byte[] bytes  = manager.extractKey(keystore, pwd, keyName);
@@ -44,25 +48,100 @@ service ProxyManager(Uri[] receivers)
                          |
                          ;
 
+        StringBuffer buf = new StringBuffer();
+        for (Certificate cert : keystore.getCertificateChain(keyName)) {
+            buf.append($|-----BEGIN CERTIFICATE-----
+                        |{Base64Format.Instance.encode(cert.toDerBytes(), pad=True, lineLength=64)}
+                        |-----END CERTIFICATE-----
+                        |
+                      );
+        }
+        String pemCert = buf.toString();
+        Time   cutoff  = clock.now + updateTimeout;
+
+        @Future Boolean allDone;
+        Future<Boolean> done = &allDone;
+
+        @Volatile Int successCount = 0;
+
+        for (Uri receiver : receivers) {
+            Updater updater = new Updater(receiver, pemKey, pemCert, hostName, report);
+            Boolean success = updater.updateProxy^(cutoff);
+            &success.whenComplete((r, x) -> {
+                if (r == True) {
+                    if (++successCount >= required) {
+                        done.complete(True);
+                    }
+                } else {
+                    // this can only be caused by a timeout
+                    done.complete(False);
+                }
+            });
+        }
+        return allDone;
+    }
+
+
+    @Override
+    void removeProxyConfig(String hostName, Reporting report) {
         for (Uri receiver : receivers) {
             Boolean success;
+            try (val _ = new Timeout(updateTimeout)) {
+                ResponseIn response = client.delete(receiver.with(path=$"/nginx/{hostName}"));
+                success = response.status == OK;
+            } catch (Exception e) {
+                success = False;
+            }
+
+            if (!success) {
+                report($|Error: Failed to remove "{hostName}" route from the proxy server "{receiver}"
+                      );
+            }
+        }
+    }
+
+    /**
+     * A simple updater service that is used to communicate with a receiver.
+     */
+    service Updater(Uri receiver, String pemKey, String pemCert, String hostName, Reporting report) {
+        /**
+         * Async update.
+         */
+        Boolean updateProxy(Time cutoff) {
+            Time now = clock.now;
+            if (now > cutoff) {
+                return False;
+            }
+
+            try (val _ = new Timeout(cutoff - now)) {
+                if (update()) {
+                    return True;
+                }
+            } catch (TimedOut e) {
+                return False;
+            }
+
+            // repeat in two seconds
+            @Future Boolean done;
+            clock.schedule(Duration.ofSeconds(2), () -> {
+                done = updateProxy^(cutoff);
+            });
+            return done;
+        }
+
+        /**
+         * Internal synchronous operation.
+         */
+        private Boolean update() {
+            Boolean success;
             String  reason;
-            try (val _ = new Timeout(receiverTimeout)) {
+            try {
                 ResponseIn response = client.put(
                         receiver.with(path=$"/nginx/{hostName}/key"), pemKey, Text);
 
                 if (response.status == OK) {
-                    StringBuffer pemCert = new StringBuffer();
-                    for (Certificate cert : keystore.getCertificateChain(keyName)) {
-                        pemCert.append(
-                                $|-----BEGIN CERTIFICATE-----
-                                 |{Base64Format.Instance.encode(cert.toDerBytes(), pad=True, lineLength=64)}
-                                 |-----END CERTIFICATE-----
-                                 |
-                                 );
-                    }
                     response = client.put(
-                        receiver.with(path=$"/nginx/{hostName}/cert"), pemCert.toString(), Text);
+                        receiver.with(path=$"/nginx/{hostName}/cert"), pemCert, Text);
                 }
                 success = response.status == OK;
                 reason  = $"Status: {response.status}";
@@ -76,24 +155,7 @@ service ProxyManager(Uri[] receivers)
                         |"{receiver}" reason="{reason}"
                       );
             }
-        }
-    }
-
-    @Override
-    void removeProxyConfig(String hostName, Reporting report) {
-        for (Uri receiver : receivers) {
-            Boolean success;
-            try (val _ = new Timeout(receiverTimeout)) {
-                ResponseIn response = client.delete(receiver.with(path=$"/nginx/{hostName}"));
-                success = response.status == OK;
-            } catch (Exception e) {
-                success = False;
-            }
-
-            if (!success) {
-                report($|Error: Failed to remove "{hostName}" route from the proxy server "{receiver}"
-                      );
-            }
+            return success;
         }
     }
 }


### PR DESCRIPTION
This change was made on [request from Michael@Compator](https://discord.com/channels/837372142576205885/1406009322307190834/1509120701116973138) 

The outline of the proposed solution is as follows:

1.  There are two new **optional** configuration settings:
    - "proxies-required": specifies a number of proxy receivers that **must** successfully process an proxy update request in order the platform to start (default value is 1); cannot be greater than the number of proxy addresses in the "proxies" element
    - "proxies-timeout": specifies a timeout value in seconds that in the case of a failure the platform will attempt to re-try the communication with the receivers

2. The basic algorithm is:
    - upon the start, the platform sends its certificate to all receivers in the "proxies" list
    - as soon as the "proxies-required" number of receivers acknowledge the update, the platform proceeds to start
    - if any failures occur, the platform will re-send the request every two seconds until either the positive ACK is received or the timeout occurs